### PR TITLE
Consider user's time zone for committed date

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
 
+  around_action :set_time_zone, if: :current_user
+
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def current_user
@@ -11,6 +13,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_time_zone(&)
+    Time.use_zone(current_user.time_zone, &)
+  end
 
   def record_not_found(error)
     path = send(:"#{error.model.downcase.pluralize}_path")

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,12 +40,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name time_zone])
   end
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: %i[name time_zone])
   end
 
   # The path used after sign up.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :incomes
   has_many :expenses
 
+  validates :time_zone, inclusion: {in: ActiveSupport::TimeZone.all.map(&:name), message: I18n.t("errors.messages.invalid")}
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,6 +9,8 @@
         <%= f.input :name %>
         <%= f.input :email %>
 
+        <%= f.input :time_zone, select_html: {class: "is-fullwidth"}, selected: resource.time_zone %>
+
         <hr>
 
         <%= f.input :password,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,6 +11,8 @@
         <%= f.input :password, input_html: {autocomplete: "new-password"} %>
         <%= f.input :password_confirmation, input_html: {autocomplete: "new-password"} %>
 
+        <%= f.input :time_zone, select_html: {class: "is-fullwidth"}, selected: "UTC" %>
+
         <div class="field pt-4">
           <%= f.button :submit, t(".sign_up"), class: "is-primary is-fullwidth" %>
         </div>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -259,6 +259,7 @@ SimpleForm.setup do |config|
     check_boxes: :check_boxes,
     file: :file,
     hidden: :hidden,
+    time_zone: :select,
     text: :text
   }
 

--- a/db/migrate/20250512082345_add_time_zone_to_users.rb
+++ b/db/migrate/20250512082345_add_time_zone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :time_zone, :string, null: false, default: "UTC"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_06_092832) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_082345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_06_092832) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.string "time_zone", default: "UTC", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     name { [Faker::Name.first_name, nil].sample }
     email { Faker::Internet.email }
     password { Faker::Internet.password }
+    time_zone { ActiveSupport::TimeZone.all.sample.name }
 
     confirmed
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,4 +55,21 @@ RSpec.describe User do
       expect(user).not_to be_valid
     end
   end
+
+  describe "#time_zone" do
+    subject(:time_zone) { user.time_zone }
+
+    it { is_expected.to be_an_instance_of(String) }
+
+    it "cannot be absent" do
+      expect(build(:user, time_zone: nil)).not_to be_valid
+    end
+
+    it "is a valid time zone name" do
+      expect(ActiveSupport::TimeZone.all.map(&:name)).to include(time_zone)
+
+      expect(build(:user, time_zone: "UTC")).to be_valid
+      expect(build(:user, time_zone: "invalid")).not_to be_valid
+    end
+  end
 end

--- a/spec/shared/authentication.rb
+++ b/spec/shared/authentication.rb
@@ -3,6 +3,8 @@ RSpec.shared_context "with authenticated user" do
   let(:user) { create(:user) }
 
   before { sign_in(user) }
+
+  around { |example| Time.use_zone(user.time_zone, &example) }
 end
 
 RSpec.shared_examples "of user authentication" do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Users" do
       fill_in "Email", with: email
       fill_in "Password", with: password, match: :first
       fill_in "Password confirmation", with: password_confirmation
+      select time_zone
 
       form.click_on t("devise.registrations.new.sign_up")
     end
@@ -19,6 +20,7 @@ RSpec.describe "Users" do
     let(:email) { user.email }
     let(:password) { user.password }
     let(:password_confirmation) { password }
+    let(:time_zone) { ActiveSupport::TimeZone.new(attributes_for(:user)[:time_zone]).to_s }
 
     it "requires confirmation of the registered user's email via a link in the sent email" do
       act
@@ -240,6 +242,7 @@ RSpec.describe "Users" do
       expect(page)
         .to have_field("Name", with: user.name)
         .and have_field("Email", with: user.email)
+        .and have_select("Time zone", selected: ActiveSupport::TimeZone.new(user.time_zone).to_s)
     end
   end
 
@@ -252,6 +255,7 @@ RSpec.describe "Users" do
       click_on user.name
 
       fill_in "Name", with: name
+      select time_zone
       fill_in "Current password", with: current_password
 
       click_on t("devise.registrations.edit.update")
@@ -259,6 +263,7 @@ RSpec.describe "Users" do
 
     let(:user) { create(:user, :with_name) }
     let(:name) { "Updated #{user.name}" }
+    let(:time_zone) { ActiveSupport::TimeZone.new(attributes_for(:user)[:time_zone]).to_s }
     let(:current_password) { user.password }
 
     it "updates user data" do
@@ -266,7 +271,9 @@ RSpec.describe "Users" do
 
       expect(success_notification).to have_content(t("devise.registrations.updated"))
       expect(navbar).to have_content(name)
-      expect(page).to have_field("Name", with: name)
+      expect(page)
+        .to have_field("Name", with: name)
+        .and have_select("Time zone", selected: time_zone)
     end
 
     it_behaves_like "validation of current password presence"


### PR DESCRIPTION
Currently, the current date is used for the transaction committed date in two cases:
- as a suggested default date when adding a transaction;
- when validating the committed date attribute.

In both cases, the current date is the application server date. However, due to time zone differences, the current date may differ from the server date for some users. This situation is taken into account by these changes.