### PR TITLE
Store transaction currency instead of determining it by account

### DIFF
--- a/app/models/accounting.rb
+++ b/app/models/accounting.rb
@@ -44,14 +44,14 @@ class Accounting
   def incomes_amount
     return zero_amount unless valid?
 
-    incomes = user.incomes.where(committed_date: from..to).includes(:destination)
+    incomes = user.incomes.where(committed_date: from..to)
     TransactionsAmount.new(incomes, currency).value
   end
 
   def expenses_amount
     return zero_amount unless valid?
 
-    expenses = user.expenses.where(committed_date: from..to).includes(:source)
+    expenses = user.expenses.where(committed_date: from..to)
     TransactionsAmount.new(expenses, currency).value
   end
 

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -2,6 +2,16 @@ class Expense < Transaction
   SOURCE_TYPE = "Account".freeze
   DESTINATION_TYPE = "ExpenseCategory".freeze
 
+  def source_id=(id)
+    super
+    sync_currency
+  end
+
+  def source=(new_source)
+    super
+    sync_currency
+  end
+
   def account
     source
   end
@@ -31,5 +41,12 @@ class Expense < Transaction
 
   def cancel
     account.deposit(amount)
+  end
+
+  private
+
+  def set_currency
+    self.source = Account.find_by(id: source_id) if source.nil? && source_id.present?
+    sync_currency
   end
 end

--- a/app/models/income.rb
+++ b/app/models/income.rb
@@ -2,6 +2,16 @@ class Income < Transaction
   SOURCE_TYPE = "IncomeCategory".freeze
   DESTINATION_TYPE = "Account".freeze
 
+  def destination_id=(id)
+    super
+    sync_currency
+  end
+
+  def destination=(new_destination)
+    super
+    sync_currency
+  end
+
   def category
     source
   end
@@ -31,5 +41,12 @@ class Income < Transaction
 
   def cancel
     account.withdraw(amount)
+  end
+
+  private
+
+  def set_currency
+    self.destination = Account.find_by(id: destination_id) if destination.nil? && destination_id.present?
+    sync_currency
   end
 end

--- a/app/operations/update_transaction.rb
+++ b/app/operations/update_transaction.rb
@@ -30,7 +30,7 @@ class UpdateTransaction < Operation
   end
 
   def new_amount
-    data[:amount] ? Monetize.parse(data[:amount], transaction.currency_for_amount) : transaction.amount
+    data[:amount] ? Monetize.parse(data[:amount], transaction.currency) : transaction.amount
   end
 
   def update_transaction

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
         not_enough_balance: The balance of account %{name} (%{balance}) cannot be reduced by %{amount}
       is_a: must be a %{model}
       is_an: must be an %{model}
+      be: must be %{expected}
       not_greater_than: cannot be greater than %{count}
       not_less_than: cannot be less than %{count}
       one_of: "must be one of: %{list}"

--- a/db/migrate/20250519082647_add_currency_to_transactions.rb
+++ b/db/migrate/20250519082647_add_currency_to_transactions.rb
@@ -1,0 +1,21 @@
+class AddCurrencyToTransactions < ActiveRecord::Migration[7.2]
+  def up
+    add_column :transactions, :currency, :string
+    set_currency_for_transactions
+    change_column_null :transactions, :currency, false
+  end
+
+  def down
+    remove_column :transactions, :currency
+  end
+
+  private
+
+  def set_currency_for_transactions
+    Money::Currency.all.each do |currency| # rubocop:disable Rails/FindEach
+      ids = Account.where(currency:).ids
+      Income.where(destination_id: ids).update_all(currency:)
+      Expense.where(source_id: ids).update_all(currency:)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_14_125051) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_19_082647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_14_125051) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "currency", null: false
     t.index ["destination_type", "destination_id"], name: "index_transactions_on_destination"
     t.index ["source_type", "source_id"], name: "index_transactions_on_source"
     t.index ["user_id"], name: "index_transactions_on_user_id"

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Transaction do
   it { is_expected.to respond_to(:correct).with(1).argument }
   it { is_expected.to respond_to(:cancel).with(0).arguments }
 
-  it { is_expected.to monetize(:amount) }
+  it { is_expected.to monetize(:amount).with_model_currency(:currency) }
 
   it_behaves_like "it has timestamps"
 
@@ -72,6 +72,19 @@ RSpec.describe Transaction do
     it "is > 0" do
       expect(amount).to be > 0
       expect(build(:transaction, amount: 0)).not_to be_valid
+    end
+  end
+
+  describe "#currency" do
+    subject(:currency) { transaction.currency }
+
+    it { is_expected.to be_an_instance_of(Money::Currency) }
+
+    it "matches related account currency" do
+      expect(currency).to eql(transaction.account.currency)
+
+      transaction.currency = Money::Currency.all.excluding(currency).sample
+      expect(transaction).not_to be_valid
     end
   end
 

--- a/spec/requests/transactions_spec.rb
+++ b/spec/requests/transactions_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe "Transactions requests" do
     let(:type) { :transaction }
     let(:attributes) do
       {
-        amount: transaction.amount + Money.from_amount(1, transaction.currency_for_amount),
+        amount: transaction.amount + Money.from_amount(1, transaction.currency),
         comment: "New #{transaction.comment}".strip,
         committed_date: transaction.committed_date.prev_day
       }
@@ -188,7 +188,7 @@ RSpec.describe "Transactions requests" do
       expect { request }.to change { transaction.reload.attributes }
 
       changed_attributes = transaction.attributes.symbolize_keys
-      changed_attributes[:amount] = Money.from_cents(changed_attributes[:amount_cents], transaction.currency_for_amount)
+      changed_attributes[:amount] = Money.from_cents(changed_attributes[:amount_cents], transaction.currency)
       expect(changed_attributes).to include(attributes)
     end
 
@@ -215,7 +215,7 @@ RSpec.describe "Transactions requests" do
         let(:attributes) { {amount: transaction.amount + diff} }
 
         context "when the new Income amount is greater than the current one" do
-          let(:diff) { Money.from_amount(1, transaction.currency_for_amount) }
+          let(:diff) { Money.from_amount(1, transaction.currency) }
 
           it "increases the Account balance by the difference between the new and current amounts" do
             expect { request }.to change { transaction.account.reload.balance }.by(diff)
@@ -223,7 +223,7 @@ RSpec.describe "Transactions requests" do
         end
 
         context "when the new Income amount is less than the current one" do
-          let(:diff) { Money.from_amount(-1, transaction.currency_for_amount) }
+          let(:diff) { Money.from_amount(-1, transaction.currency) }
 
           it "decreases the Account balance by the difference between the new and current amounts" do
             expect { request }.to change { transaction.account.reload.balance }.by(diff)
@@ -325,7 +325,7 @@ RSpec.describe "Transactions requests" do
         let(:attributes) { {amount: transaction.amount + diff} }
 
         context "when the new Expense amount is greater than the current one" do
-          let(:diff) { Money.from_amount(1, transaction.currency_for_amount) }
+          let(:diff) { Money.from_amount(1, transaction.currency) }
 
           it "decreases the Account balance by the difference between the new and current amounts" do
             expect { request }.to change { transaction.account.reload.balance }.by(-diff)
@@ -343,7 +343,7 @@ RSpec.describe "Transactions requests" do
         end
 
         context "when the new Expense amount is less than the current one" do
-          let(:diff) { Money.from_amount(-1, transaction.currency_for_amount) }
+          let(:diff) { Money.from_amount(-1, transaction.currency) }
 
           it "increases the Account balance by the difference between the new and current amounts" do
             expect { request }.to change { transaction.account.reload.balance }.by(-diff)

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -325,7 +325,7 @@ RSpec.describe "Transactions" do
     let(:current_account) { create(:account, user:, balance: current_account_balance) }
     let(:current_account_balance) { 100 }
     let!(:income_category) { create(:income_category, user:, name: "Not #{income.category.name}") }
-    let(:amount) { income.amount + Money.from_amount(1, income.currency_for_amount) }
+    let(:amount) { income.amount + Money.from_amount(1, income.currency) }
     let(:comment) { "Updated #{income.comment}" }
     let(:account_change) { false }
 
@@ -342,7 +342,7 @@ RSpec.describe "Transactions" do
     it_behaves_like "validation of transaction amount positivity"
 
     context "when amount decreases" do
-      let(:amount) { income.amount - Money.from_amount(1, income.currency_for_amount) }
+      let(:amount) { income.amount - Money.from_amount(1, income.currency) }
 
       context "when the difference between the new and current amounts is greater than account balance" do
         let(:current_account_balance) { 0 }
@@ -408,7 +408,7 @@ RSpec.describe "Transactions" do
     let(:current_account) { create(:account, user:, balance: current_account_balance) }
     let(:current_account_balance) { 100 }
     let!(:expense_category) { create(:expense_category, user:, name: "Not #{expense.category.name}") }
-    let(:amount) { expense.amount - Money.from_amount(1, expense.currency_for_amount) }
+    let(:amount) { expense.amount - Money.from_amount(1, expense.currency) }
     let(:comment) { "Updated #{expense.comment}" }
     let(:account_change) { false }
 
@@ -425,7 +425,7 @@ RSpec.describe "Transactions" do
     it_behaves_like "validation of transaction amount positivity"
 
     context "when amount increases" do
-      let(:amount) { expense.amount + Money.from_amount(1, expense.currency_for_amount) }
+      let(:amount) { expense.amount + Money.from_amount(1, expense.currency) }
 
       context "when the difference between the new and current amounts is greater than account balance" do
         let(:current_account_balance) { 0 }


### PR DESCRIPTION
This allows to remove queries created by `.includes` for accounting.